### PR TITLE
Fix path parsing and multiline f-string issues

### DIFF
--- a/features/file_ingest.py
+++ b/features/file_ingest.py
@@ -9,11 +9,12 @@ class FileIngest:
         self._create_thumbnail_dir()
 
     def ingestFile(self, filepath):
+        """Ingest a file and return the DB ready tuple."""
         # (title, file_path, media_type, file_url, tags, thumbnail_path, duration)
-        split_file = filepath.split("\\")
+        filename = os.path.basename(filepath)
 
-        title = self.get_title(split_file)
-        media_type = self.get_mediaType(split_file)
+        title = self.get_title(filename)
+        media_type = self.get_mediaType(filename)
         file_url = None
         tags = None
 
@@ -31,7 +32,8 @@ class FileIngest:
             clip = VideoFileClip(filepath)
             duration = clip.duration
 
-            thumbnail_name = str(os.path.basename(filepath).replace("mp4", "png"))
+            base, _ = os.path.splitext(os.path.basename(filepath))
+            thumbnail_name = f"{base}.png"
             thumbnail_path = os.path.join(
                 self.thumbnail_dir,
                 thumbnail_name
@@ -47,20 +49,22 @@ class FileIngest:
 
     def _create_thumbnail_dir(self):
         if not os.path.isdir(self.thumbnail_dir):
-            os.mkdir(self.thumbnail_dir)
+            os.makedirs(self.thumbnail_dir, exist_ok=True)
 
     @staticmethod
-    def get_title(splitfile):
-        return splitfile[-1].split(".")[0]
+    def get_title(filename: str) -> str:
+        """Return the filename without its extension."""
+        return os.path.splitext(filename)[0]
 
     @staticmethod
-    def get_mediaType(splitfile):
-        extension = splitfile[-1].split(".")[1]
-        if extension in ["mp4"]: # Video Formats
+    def get_mediaType(filename: str) -> str:
+        """Return the media type based on file extension."""
+        extension = os.path.splitext(filename)[1].lstrip(".").lower()
+        if extension in ["mp4"]:  # Video Formats
             return "Video"
-        elif extension in ["gif"]: # Animated Formats
+        elif extension in ["gif"]:  # Animated Formats
             return "Animated"
-        elif extension in ["jpg", "png", "jpeg"]: # Image Formats
+        elif extension in ["jpg", "png", "jpeg"]:  # Image Formats
             return "Image"
         else:
             return "None"

--- a/views/file_ingest_window.py
+++ b/views/file_ingest_window.py
@@ -113,10 +113,10 @@ class FileIngestWindow(QDialog):
 
         for i in range(0, len(existing_files)):             # "i" is our row
             for i2 in range(0, len(existing_files[i])):     # "i2" is our column
-                if i2 == 2:                                 # 2 is the Index of the File Path
-                    itemText = f".../{self.fileIngestController.shortenFilePath(
-                        str(existing_files[i][i2])
-                    )}"
+                if i2 == 2:  # 2 is the index of the File Path
+                    itemText = (
+                        f".../{self.fileIngestController.shortenFilePath(str(existing_files[i][i2]))}"
+                    )
 
                 else:
                     itemText = str(existing_files[i][i2])

--- a/widgets/viewer.py
+++ b/widgets/viewer.py
@@ -1,5 +1,6 @@
 from PySide6.QtWidgets import QWidget, QLabel, QGridLayout, QStackedWidget
 from PySide6.QtGui import QPixmap, Qt, QMovie
+import os
 
 from widgets.video_viewer import VideoViewer
 
@@ -84,11 +85,13 @@ class Viewer(QWidget):
     
     def updateMediaInfo(self):
         total_media = self.dbController.getTableDimensions()[0]
-        file_path = self.fileRow[2].split("\\")
-        file_path = "\\".join(file_path[-2:])
+        path_parts = self.fileRow[2].split(os.sep)
+        file_path = os.path.join(*path_parts[-2:])
 
-        self.mediaIndex.setText(f"File Index: {self.fileRow[0]} / {total_media}")
-        self.mediaPath.setText(f"File Path: ..\\{file_path}")
+        self.mediaIndex.setText(
+            f"File Index: {self.fileRow[0]} / {total_media}"
+        )
+        self.mediaPath.setText(f"File Path: ..{os.sep}{file_path}")
 
     def _displayImage(self):
         filepath = self.fileRow[2]


### PR DESCRIPTION
## Summary
- ensure ingest uses os.path for cross-platform support
- fix thumbnail generation path logic
- sanitize path display in viewer
- correct multiline f-string in ingest window

## Testing
- `python3 -m py_compile features/file_ingest.py`
- `python3 -m py_compile widgets/viewer.py`
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68671a43e1c4832ca81424a5e6f33026